### PR TITLE
chore: source StreamParser type from @codemirror/language instead of …

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@ A CodeMirror 6 mode for elixir. Most of the code is from [codemirror-mode-elixir
 
 ## Installation
 ```shell
-npm install codemirror-lang-elixir @codemirror/stream-parser
+npm install codemirror-lang-elixir @codemirror/language
 ```
 
 ## Usage
 Treat it the same way as a [legacy-modes](https://github.com/codemirror/legacy-modes) import:
 ```js
-import { StreamLanguage } from '@codemirror/stream-parser'
+import { StreamLanguage } from '@codemirror/language'
 import { elixir } from 'codemirror-lang-elixir'
 
 const lang = StreamLanguage.define(elixir)

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,3 @@
-import { StreamParser } from '@codemirror/stream-parser'
+import { StreamParser } from '@codemirror/language'
 
 export declare const elixir: StreamParser<unknown>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,28 @@
 {
   "name": "codemirror-lang-elixir",
   "version": "2.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
-  "dependencies": {
-    "@codemirror/highlight": {
+  "packages": {
+    "": {
+      "name": "codemirror-lang-elixir",
+      "version": "2.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@codemirror/language": "^6.2.1",
+        "rollup": "2.60.0"
+      },
+      "peerDependencies": {
+        "@codemirror/stream-parser": ">=0.18.0"
+      }
+    },
+    "node_modules/@codemirror/highlight": {
       "version": "0.19.6",
       "resolved": "https://registry.npmjs.org/@codemirror/highlight/-/highlight-0.19.6.tgz",
       "integrity": "sha512-+eibu6on9quY8uN3xJ/n3rH+YIDLlpX7YulVmFvqAIz/ukRQ5tWaBmB7fMixHmnmRIRBRZgB8rNtonuMwZSAHQ==",
-      "dev": true,
-      "requires": {
+      "deprecated": "As of 0.20.0, this package has been split between @lezer/highlight and @codemirror/language",
+      "peer": true,
+      "dependencies": {
         "@codemirror/language": "^0.19.0",
         "@codemirror/rangeset": "^0.19.0",
         "@codemirror/state": "^0.19.0",
@@ -18,12 +31,12 @@
         "style-mod": "^4.0.0"
       }
     },
-    "@codemirror/language": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.19.4.tgz",
-      "integrity": "sha512-yLnLDUkK00BlRVXpPkoJMYEssYKuRLOmK+DdJJ8zOOD4D62T7bSQ05NPyWzWr3PQX1k7sxGICGKR7INzfv9Snw==",
-      "dev": true,
-      "requires": {
+    "node_modules/@codemirror/highlight/node_modules/@codemirror/language": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.19.10.tgz",
+      "integrity": "sha512-yA0DZ3RYn2CqAAGW62VrU8c4YxscMQn45y/I9sjBlqB1e2OTQLg4CCkMBuMSLXk4xaqjlsgazeOQWaJQOKfV8Q==",
+      "peer": true,
+      "dependencies": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/text": "^0.19.0",
         "@codemirror/view": "^0.19.0",
@@ -31,30 +44,78 @@
         "@lezer/lr": "^0.15.0"
       }
     },
-    "@codemirror/rangeset": {
+    "node_modules/@codemirror/language": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.2.1.tgz",
+      "integrity": "sha512-MC3svxuvIj0MRpFlGHxLS6vPyIdbTr2KKPEW46kCoCXw2ktb4NTkpkPBI/lSP/FoNXLCBJ0mrnUi1OoZxtpW1Q==",
+      "dev": true,
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/language/node_modules/@codemirror/state": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.1.1.tgz",
+      "integrity": "sha512-2s+aXsxmAwnR3Rd+JDHPG/1lw0YsA9PEwl7Re88gHJHGfxyfEzKBmsN4rr53RyPIR4lzbbhJX0DCq0WlqlBIRw==",
+      "dev": true
+    },
+    "node_modules/@codemirror/language/node_modules/@codemirror/view": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.2.0.tgz",
+      "integrity": "sha512-3emW1symh+GoteFMBPsltjmF790U/trouLILATh3JodbF/z98HvcQh2g3+H6dfNIHx16uNonsAF4mNzVr1TJNA==",
+      "dev": true,
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "style-mod": "^4.0.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@codemirror/language/node_modules/@lezer/common": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.0.0.tgz",
+      "integrity": "sha512-ohydQe+Hb+w4oMDvXzs8uuJd2NoA3D8YDcLiuDsLqH+yflDTPEpgCsWI3/6rH5C3BAedtH1/R51dxENldQceEA==",
+      "dev": true
+    },
+    "node_modules/@codemirror/language/node_modules/@lezer/lr": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.2.1.tgz",
+      "integrity": "sha512-RpHRs+Q+5tPsXtobSfSeRFRAnTRD0e4bApDvo74O+JiaWq9812x5S8WgftNX67owdaTQXCB5E8XZGALo4Wt77A==",
+      "dev": true,
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/rangeset": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@codemirror/rangeset/-/rangeset-0.19.2.tgz",
       "integrity": "sha512-5d+X8LtmeZtfFtKrSx57bIHRUpKv2HD0b74clp4fGA7qJLLfYehF6FGkJJxJb8lKsqAga1gdjjWr0jiypmIxoQ==",
-      "dev": true,
-      "requires": {
+      "deprecated": "As of 0.20.0, this package has been merged into @codemirror/state",
+      "peer": true,
+      "dependencies": {
         "@codemirror/state": "^0.19.0"
       }
     },
-    "@codemirror/state": {
+    "node_modules/@codemirror/state": {
       "version": "0.19.5",
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.19.5.tgz",
       "integrity": "sha512-a3bJnkFuh4Z36nuOzAYobWViQ9eq5ux2wOb/46jUl+0Sj2BGrdz+pY1L+y2NUZhwPyWGcIrBtranr5P0rEEq8A==",
-      "dev": true,
-      "requires": {
+      "peer": true,
+      "dependencies": {
         "@codemirror/text": "^0.19.0"
       }
     },
-    "@codemirror/stream-parser": {
+    "node_modules/@codemirror/stream-parser": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@codemirror/stream-parser/-/stream-parser-0.19.2.tgz",
       "integrity": "sha512-hBKRQlyu8GUOrY33xZ6/1kAfNZ8ZUm6cX9a7mPx8zAAqnpz/fpksC/qJRrkg1mPMBwxm+JG4fqAwDGJ3gLVniQ==",
-      "dev": true,
-      "requires": {
+      "deprecated": "As of 0.20.0, this package has been merged into @codemirror/language",
+      "peer": true,
+      "dependencies": {
         "@codemirror/highlight": "^0.19.0",
         "@codemirror/language": "^0.19.0",
         "@codemirror/state": "^0.19.0",
@@ -63,17 +124,245 @@
         "@lezer/lr": "^0.15.0"
       }
     },
+    "node_modules/@codemirror/stream-parser/node_modules/@codemirror/language": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.19.10.tgz",
+      "integrity": "sha512-yA0DZ3RYn2CqAAGW62VrU8c4YxscMQn45y/I9sjBlqB1e2OTQLg4CCkMBuMSLXk4xaqjlsgazeOQWaJQOKfV8Q==",
+      "peer": true,
+      "dependencies": {
+        "@codemirror/state": "^0.19.0",
+        "@codemirror/text": "^0.19.0",
+        "@codemirror/view": "^0.19.0",
+        "@lezer/common": "^0.15.5",
+        "@lezer/lr": "^0.15.0"
+      }
+    },
+    "node_modules/@codemirror/text": {
+      "version": "0.19.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/text/-/text-0.19.5.tgz",
+      "integrity": "sha512-Syu5Xc7tZzeUAM/y4fETkT0zgGr48rDG+w4U38bPwSIUr+L9S/7w2wDE1WGNzjaZPz12F6gb1gxWiSTg9ocLow==",
+      "deprecated": "As of 0.20.0, this package has been merged into @codemirror/state",
+      "peer": true
+    },
+    "node_modules/@codemirror/view": {
+      "version": "0.19.16",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.16.tgz",
+      "integrity": "sha512-VumZoAQRX9BhHU0cD4++izO4mfCH36J61xz9MxtfOKEggzuKlyuGDrdix67FhoDfYiDRvqv9lt1J5YZ/zdU2WA==",
+      "peer": true,
+      "dependencies": {
+        "@codemirror/rangeset": "^0.19.0",
+        "@codemirror/state": "^0.19.3",
+        "@codemirror/text": "^0.19.0",
+        "style-mod": "^4.0.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@lezer/common": {
+      "version": "0.15.8",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.15.8.tgz",
+      "integrity": "sha512-zpS/xty48huX4uBidupmWDYCRBYpVtoTiFhzYhd6GsQwU67WsdSImdWzZJDrF/DhcQ462wyrZahHlo2grFB5ig==",
+      "peer": true
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.0.0.tgz",
+      "integrity": "sha512-nsCnNtim90UKsB5YxoX65v3GEIw3iCHw9RM2DtdgkiqAbKh9pCdvi8AWNwkYf10Lu6fxNhXPpkpHbW6mihhvJA==",
+      "dev": true,
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/highlight/node_modules/@lezer/common": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.0.0.tgz",
+      "integrity": "sha512-ohydQe+Hb+w4oMDvXzs8uuJd2NoA3D8YDcLiuDsLqH+yflDTPEpgCsWI3/6rH5C3BAedtH1/R51dxENldQceEA==",
+      "dev": true
+    },
+    "node_modules/@lezer/lr": {
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.15.4.tgz",
+      "integrity": "sha512-vwgG80sihEGJn6wJp6VijXrnzVai/KPva/OzYKaWvIx0IiXKjoMQ8UAwcgpSBwfS4Fbz3IKOX/cCNXU3r1FvpQ==",
+      "peer": true,
+      "dependencies": {
+        "@lezer/common": "^0.15.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "2.60.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.60.0.tgz",
+      "integrity": "sha512-cHdv9GWd58v58rdseC8e8XIaPUo8a9cgZpnCMMDGZFDZKEODOiPPEQFXLriWr/TjXzhPPmG5bkAztPsOARIcGQ==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/style-mod": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.0.tgz",
+      "integrity": "sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw=="
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.4.tgz",
+      "integrity": "sha512-tOhfEwEzFLJzf6d1ZPkYfGj+FWhIpBux9ppoP3rlclw3Z0BZv3N7b7030Z1kYth+6rDuAsXUFr+d0VE6Ed1ikw=="
+    }
+  },
+  "dependencies": {
+    "@codemirror/highlight": {
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/highlight/-/highlight-0.19.6.tgz",
+      "integrity": "sha512-+eibu6on9quY8uN3xJ/n3rH+YIDLlpX7YulVmFvqAIz/ukRQ5tWaBmB7fMixHmnmRIRBRZgB8rNtonuMwZSAHQ==",
+      "peer": true,
+      "requires": {
+        "@codemirror/language": "^0.19.0",
+        "@codemirror/rangeset": "^0.19.0",
+        "@codemirror/state": "^0.19.0",
+        "@codemirror/view": "^0.19.0",
+        "@lezer/common": "^0.15.0",
+        "style-mod": "^4.0.0"
+      },
+      "dependencies": {
+        "@codemirror/language": {
+          "version": "0.19.10",
+          "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.19.10.tgz",
+          "integrity": "sha512-yA0DZ3RYn2CqAAGW62VrU8c4YxscMQn45y/I9sjBlqB1e2OTQLg4CCkMBuMSLXk4xaqjlsgazeOQWaJQOKfV8Q==",
+          "peer": true,
+          "requires": {
+            "@codemirror/state": "^0.19.0",
+            "@codemirror/text": "^0.19.0",
+            "@codemirror/view": "^0.19.0",
+            "@lezer/common": "^0.15.5",
+            "@lezer/lr": "^0.15.0"
+          }
+        }
+      }
+    },
+    "@codemirror/language": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.2.1.tgz",
+      "integrity": "sha512-MC3svxuvIj0MRpFlGHxLS6vPyIdbTr2KKPEW46kCoCXw2ktb4NTkpkPBI/lSP/FoNXLCBJ0mrnUi1OoZxtpW1Q==",
+      "dev": true,
+      "requires": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      },
+      "dependencies": {
+        "@codemirror/state": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.1.1.tgz",
+          "integrity": "sha512-2s+aXsxmAwnR3Rd+JDHPG/1lw0YsA9PEwl7Re88gHJHGfxyfEzKBmsN4rr53RyPIR4lzbbhJX0DCq0WlqlBIRw==",
+          "dev": true
+        },
+        "@codemirror/view": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.2.0.tgz",
+          "integrity": "sha512-3emW1symh+GoteFMBPsltjmF790U/trouLILATh3JodbF/z98HvcQh2g3+H6dfNIHx16uNonsAF4mNzVr1TJNA==",
+          "dev": true,
+          "requires": {
+            "@codemirror/state": "^6.0.0",
+            "style-mod": "^4.0.0",
+            "w3c-keyname": "^2.2.4"
+          }
+        },
+        "@lezer/common": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.0.0.tgz",
+          "integrity": "sha512-ohydQe+Hb+w4oMDvXzs8uuJd2NoA3D8YDcLiuDsLqH+yflDTPEpgCsWI3/6rH5C3BAedtH1/R51dxENldQceEA==",
+          "dev": true
+        },
+        "@lezer/lr": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.2.1.tgz",
+          "integrity": "sha512-RpHRs+Q+5tPsXtobSfSeRFRAnTRD0e4bApDvo74O+JiaWq9812x5S8WgftNX67owdaTQXCB5E8XZGALo4Wt77A==",
+          "dev": true,
+          "requires": {
+            "@lezer/common": "^1.0.0"
+          }
+        }
+      }
+    },
+    "@codemirror/rangeset": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/rangeset/-/rangeset-0.19.2.tgz",
+      "integrity": "sha512-5d+X8LtmeZtfFtKrSx57bIHRUpKv2HD0b74clp4fGA7qJLLfYehF6FGkJJxJb8lKsqAga1gdjjWr0jiypmIxoQ==",
+      "peer": true,
+      "requires": {
+        "@codemirror/state": "^0.19.0"
+      }
+    },
+    "@codemirror/state": {
+      "version": "0.19.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.19.5.tgz",
+      "integrity": "sha512-a3bJnkFuh4Z36nuOzAYobWViQ9eq5ux2wOb/46jUl+0Sj2BGrdz+pY1L+y2NUZhwPyWGcIrBtranr5P0rEEq8A==",
+      "peer": true,
+      "requires": {
+        "@codemirror/text": "^0.19.0"
+      }
+    },
+    "@codemirror/stream-parser": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/stream-parser/-/stream-parser-0.19.2.tgz",
+      "integrity": "sha512-hBKRQlyu8GUOrY33xZ6/1kAfNZ8ZUm6cX9a7mPx8zAAqnpz/fpksC/qJRrkg1mPMBwxm+JG4fqAwDGJ3gLVniQ==",
+      "peer": true,
+      "requires": {
+        "@codemirror/highlight": "^0.19.0",
+        "@codemirror/language": "^0.19.0",
+        "@codemirror/state": "^0.19.0",
+        "@codemirror/text": "^0.19.0",
+        "@lezer/common": "^0.15.0",
+        "@lezer/lr": "^0.15.0"
+      },
+      "dependencies": {
+        "@codemirror/language": {
+          "version": "0.19.10",
+          "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.19.10.tgz",
+          "integrity": "sha512-yA0DZ3RYn2CqAAGW62VrU8c4YxscMQn45y/I9sjBlqB1e2OTQLg4CCkMBuMSLXk4xaqjlsgazeOQWaJQOKfV8Q==",
+          "peer": true,
+          "requires": {
+            "@codemirror/state": "^0.19.0",
+            "@codemirror/text": "^0.19.0",
+            "@codemirror/view": "^0.19.0",
+            "@lezer/common": "^0.15.5",
+            "@lezer/lr": "^0.15.0"
+          }
+        }
+      }
+    },
     "@codemirror/text": {
       "version": "0.19.5",
       "resolved": "https://registry.npmjs.org/@codemirror/text/-/text-0.19.5.tgz",
       "integrity": "sha512-Syu5Xc7tZzeUAM/y4fETkT0zgGr48rDG+w4U38bPwSIUr+L9S/7w2wDE1WGNzjaZPz12F6gb1gxWiSTg9ocLow==",
-      "dev": true
+      "peer": true
     },
     "@codemirror/view": {
       "version": "0.19.16",
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.16.tgz",
       "integrity": "sha512-VumZoAQRX9BhHU0cD4++izO4mfCH36J61xz9MxtfOKEggzuKlyuGDrdix67FhoDfYiDRvqv9lt1J5YZ/zdU2WA==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@codemirror/rangeset": "^0.19.0",
         "@codemirror/state": "^0.19.3",
@@ -86,13 +375,30 @@
       "version": "0.15.8",
       "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.15.8.tgz",
       "integrity": "sha512-zpS/xty48huX4uBidupmWDYCRBYpVtoTiFhzYhd6GsQwU67WsdSImdWzZJDrF/DhcQ462wyrZahHlo2grFB5ig==",
-      "dev": true
+      "peer": true
+    },
+    "@lezer/highlight": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.0.0.tgz",
+      "integrity": "sha512-nsCnNtim90UKsB5YxoX65v3GEIw3iCHw9RM2DtdgkiqAbKh9pCdvi8AWNwkYf10Lu6fxNhXPpkpHbW6mihhvJA==",
+      "dev": true,
+      "requires": {
+        "@lezer/common": "^1.0.0"
+      },
+      "dependencies": {
+        "@lezer/common": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.0.0.tgz",
+          "integrity": "sha512-ohydQe+Hb+w4oMDvXzs8uuJd2NoA3D8YDcLiuDsLqH+yflDTPEpgCsWI3/6rH5C3BAedtH1/R51dxENldQceEA==",
+          "dev": true
+        }
+      }
     },
     "@lezer/lr": {
       "version": "0.15.4",
       "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.15.4.tgz",
       "integrity": "sha512-vwgG80sihEGJn6wJp6VijXrnzVai/KPva/OzYKaWvIx0IiXKjoMQ8UAwcgpSBwfS4Fbz3IKOX/cCNXU3r1FvpQ==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@lezer/common": "^0.15.0"
       }
@@ -116,14 +422,12 @@
     "style-mod": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.0.tgz",
-      "integrity": "sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw==",
-      "dev": true
+      "integrity": "sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw=="
     },
     "w3c-keyname": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.4.tgz",
-      "integrity": "sha512-tOhfEwEzFLJzf6d1ZPkYfGj+FWhIpBux9ppoP3rlclw3Z0BZv3N7b7030Z1kYth+6rDuAsXUFr+d0VE6Ed1ikw==",
-      "dev": true
+      "integrity": "sha512-tOhfEwEzFLJzf6d1ZPkYfGj+FWhIpBux9ppoP3rlclw3Z0BZv3N7b7030Z1kYth+6rDuAsXUFr+d0VE6Ed1ikw=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codemirror-lang-elixir",
   "description": "A codemirror.next mode for elixir.",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "type": "module",
   "main": "index.cjs",
   "module": "index.js",
@@ -32,10 +32,10 @@
   },
   "homepage": "https://github.com/sachinraja/codemirror-lang-elixir#readme",
   "peerDependencies": {
-    "@codemirror/stream-parser": ">=0.18.0"
+    "@codemirror/language": "^6.2.1"
   },
   "devDependencies": {
-    "@codemirror/stream-parser": "0.19.2",
+    "@codemirror/language": "^6.2.1",
     "rollup": "2.60.0"
   }
 }


### PR DESCRIPTION
…deprecated stream-parser lib

Looking to use this in a project using codemirror 6.0.1 - this devdep is conflicting with the same type pulled from more up to date `/language` - see deprecation message here: https://www.npmjs.com/package/@codemirror/stream-parser

my error for reference 

```
      Types of parameters 'stream' and 'stream' are incompatible.
        Type 'import(".../.pnpm/@codemirror+language@6.2.0/node_modules/@codemirror/language/dist/index").StringStream' is not assignable to type 'import(".../.pnpm/@codemirror+stream-parser@0.19.9/node_modules/@codemirror/stream-parser/dist/index").StringStream'.
          Types have separate declarations of a private property 'tabSize'.